### PR TITLE
Add adjustable-rate mortgage learn module

### DIFF
--- a/learn-arm.html
+++ b/learn-arm.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Adjustable-Rate Mortgages - Learn - BCSB</title>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+    <link href="styles.css" rel="stylesheet">
+</head>
+<body>
+    <header>
+        <div class="container" style="display: flex; align-items: center; justify-content: space-between;">
+            <div>
+                <h1>Adjustable-Rate Mortgages</h1>
+                <div class="subtitle">Understand how ARM products adjust over time</div>
+            </div>
+            <a href="learn.html" class="btn btn-primary">
+                <i class="fas fa-arrow-left"></i> Back
+            </a>
+        </div>
+    </header>
+
+    <div class="container">
+        <div class="card">
+            <div class="card-header"><i class="fas fa-lightbulb"></i> Explore ARM Types</div>
+            <div class="card-body">
+                <div class="form-group">
+                    <label for="arm-select">Select an ARM product:</label>
+                    <select id="arm-select"></select>
+                </div>
+                <div id="arm-info" style="display:none;">
+                    <h3 id="arm-name"></h3>
+                    <table class="arm-detail-table">
+                        <tbody>
+                            <tr><td>Initial Period</td><td id="arm-initial-period"></td></tr>
+                            <tr><td>Adjustment Period</td><td id="arm-subsequent-period"></td></tr>
+                            <tr><td>Initial Cap</td><td id="arm-initial-cap"></td></tr>
+                            <tr><td>Subsequent Cap</td><td id="arm-subsequent-cap"></td></tr>
+                            <tr><td>Lifetime Cap</td><td id="arm-lifetime-cap"></td></tr>
+                            <tr><td>Margin</td><td id="arm-margin"></td></tr>
+                            <tr><td>Index</td><td id="arm-index"></td></tr>
+                        </tbody>
+                    </table>
+                    <p id="arm-explanation"></p>
+                </div>
+            </div>
+        </div>
+
+        <div class="card">
+            <div class="card-header"><i class="fas fa-table"></i> ARM Reference Table</div>
+            <div class="card-body">
+                <table id="arm-table">
+                    <thead>
+                        <tr>
+                            <th>Plan</th>
+                            <th>Initial Period (mo)</th>
+                            <th>Adj. Period (mo)</th>
+                            <th>Initial Cap</th>
+                            <th>Subsequent Cap</th>
+                            <th>Lifetime Cap</th>
+                            <th>Margin</th>
+                            <th>Index</th>
+                        </tr>
+                    </thead>
+                    <tbody></tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+    <script src="learn-arm.js"></script>
+</body>
+</html>

--- a/learn-arm.js
+++ b/learn-arm.js
@@ -1,0 +1,104 @@
+// Script for Adjustable-Rate Mortgage learning page
+
+document.addEventListener('DOMContentLoaded', () => {
+    fetch('armtable.csv')
+        .then(response => response.text())
+        .then(text => {
+            const arms = parseArmCSV(text);
+            populateSelect(arms);
+            populateTable(arms);
+        })
+        .catch(err => console.error('Error loading ARM data:', err));
+});
+
+function parseArmCSV(text) {
+    // Remove BOM if present and split into lines
+    const lines = text.replace(/\ufeff/g, '').trim().split(/\r?\n/);
+    const dataLines = lines.slice(1); // skip header
+    const arms = [];
+    const seen = new Set();
+
+    dataLines.forEach(line => {
+        if (!line.trim()) return;
+        // remove all quotes created by Excel triple quoting
+        const cleaned = line.replace(/"""/g, '').replace(/"/g, '').trim();
+        const parts = cleaned.split(',');
+        if (parts.length < 8) return;
+        const arm = {
+            arm_plancode: parts[0],
+            initial_period: parts[1],
+            subsequent_period: parts[2],
+            lifetime_cap: parts[3],
+            initial_cap: parts[4],
+            subsequent_cap: parts[5],
+            margin: parts[6],
+            index: parts[7]
+        };
+        if (!seen.has(arm.arm_plancode)) {
+            arms.push(arm);
+            seen.add(arm.arm_plancode);
+        }
+    });
+    return arms;
+}
+
+function populateSelect(arms) {
+    const select = document.getElementById('arm-select');
+    if (!select) return;
+    select.innerHTML = '<option value="">-- Choose an ARM --</option>';
+    arms.forEach(arm => {
+        const opt = document.createElement('option');
+        opt.value = arm.arm_plancode;
+        opt.textContent = `${arm.arm_plancode} ARM`;
+        select.appendChild(opt);
+    });
+    select.addEventListener('change', () => showDetails(select.value, arms));
+}
+
+function populateTable(arms) {
+    const tbody = document.querySelector('#arm-table tbody');
+    if (!tbody) return;
+    arms.forEach(arm => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `
+            <td>${arm.arm_plancode}</td>
+            <td>${arm.initial_period}</td>
+            <td>${arm.subsequent_period}</td>
+            <td>${arm.initial_cap}</td>
+            <td>${arm.subsequent_cap}</td>
+            <td>${arm.lifetime_cap}</td>
+            <td>${arm.margin}</td>
+            <td>${arm.index}</td>`;
+        tbody.appendChild(tr);
+    });
+}
+
+function showDetails(code, arms) {
+    const container = document.getElementById('arm-info');
+    if (!container) return;
+    if (!code) {
+        container.style.display = 'none';
+        return;
+    }
+    const arm = arms.find(a => a.arm_plancode === code);
+    if (!arm) return;
+
+    document.getElementById('arm-name').textContent = `${code} ARM`;
+    document.getElementById('arm-initial-period').textContent = `${arm.initial_period} months`;
+    document.getElementById('arm-subsequent-period').textContent = `${arm.subsequent_period} months`;
+    document.getElementById('arm-initial-cap').textContent = arm.initial_cap;
+    document.getElementById('arm-subsequent-cap').textContent = arm.subsequent_cap;
+    document.getElementById('arm-lifetime-cap').textContent = arm.lifetime_cap;
+    document.getElementById('arm-margin').textContent = arm.margin;
+    document.getElementById('arm-index').textContent = arm.index;
+
+    const initMonths = parseInt(arm.initial_period, 10);
+    const initYears = (initMonths % 12 === 0) ? `${initMonths / 12} year${initMonths/12>1?'s':''}` : `${initMonths} months`;
+    const explanationPart1 = `The ${code} ARM starts with a fixed rate for ${initYears} before adjusting every ${arm.subsequent_period} months.`;
+    const explanation = explanationPart1 +
+        ` The first adjustment is limited to ${arm.initial_cap} and later adjustments to ${arm.subsequent_cap}, with a lifetime cap of ${arm.lifetime_cap}.` +
+        ` Rates are based on the ${arm.index} plus a margin of ${arm.margin}.`;
+    document.getElementById('arm-explanation').textContent = explanation;
+
+    container.style.display = 'block';
+}

--- a/learn.html
+++ b/learn.html
@@ -6,6 +6,52 @@
     <title>Learn - BCSB</title>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
     <link href="styles.css" rel="stylesheet">
+    <style>
+        .topic-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 20px;
+            margin: 2rem 0;
+        }
+
+        .topic-card {
+            border: 2px solid var(--border-color);
+            border-radius: var(--border-radius);
+            padding: 2rem;
+            text-align: center;
+            cursor: pointer;
+            transition: var(--transition);
+            background-color: var(--light);
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .topic-card:hover {
+            border-color: var(--primary);
+            background-color: var(--primary-light);
+            transform: translateY(-5px);
+            box-shadow: var(--shadow-lg);
+        }
+
+        .topic-icon {
+            font-size: 3rem;
+            margin-bottom: 1.5rem;
+            color: var(--primary);
+        }
+
+        .topic-title {
+            font-size: 1.25rem;
+            font-weight: 600;
+            margin-bottom: 0.5rem;
+        }
+
+        .topic-description {
+            font-size: 0.9rem;
+            color: var(--secondary);
+        }
+    </style>
 </head>
 <body>
     <header>
@@ -21,10 +67,11 @@
     </header>
 
     <div class="container">
-        <div class="card">
-            <div class="card-body" style="text-align: center;">
-                <h2>Coming Soon!</h2>
-                <p>This section is currently under development. Please check back later for more information.</p>
+        <div class="topic-grid">
+            <div class="topic-card" onclick="window.location.href='learn-arm.html';">
+                <div class="topic-icon"><i class="fas fa-chart-line"></i></div>
+                <div class="topic-title">Adjustable-Rate Mortgages</div>
+                <div class="topic-description">Explore how ARM products adjust over time.</div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- Replace learn landing placeholder with topic card linking to adjustable-rate mortgage education
- Add interactive ARM learning page that reads CSV data, displays plan details, and builds a reference table

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3009540808329acc66ff1c99c107b