### PR TITLE
Redesign construction financing Program Snapshot and process contacts

### DIFF
--- a/learn-construction.html
+++ b/learn-construction.html
@@ -116,6 +116,134 @@
             display: none !important;
         }
 
+        /* Program Snapshot */
+        .snapshot-intro {
+            margin-bottom: 1.25rem;
+            color: var(--dark);
+        }
+
+        .snapshot-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 1rem;
+            margin-bottom: 1.5rem;
+        }
+
+        .snapshot-fact {
+            background-color: var(--light);
+            border: 1px solid var(--border-color);
+            border-radius: var(--border-radius);
+            padding: 1.25rem;
+            text-align: center;
+        }
+
+        .snapshot-icon {
+            width: 46px;
+            height: 46px;
+            margin: 0 auto 0.75rem;
+            border-radius: 50%;
+            background-color: rgba(0, 102, 72, 0.1);
+            color: var(--primary);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 1.2rem;
+        }
+
+        .snapshot-value {
+            font-size: 1.1rem;
+            font-weight: 700;
+            color: var(--primary);
+            margin-bottom: 0.35rem;
+        }
+
+        .snapshot-label {
+            font-size: 0.85rem;
+            color: var(--secondary);
+            line-height: 1.4;
+        }
+
+        .snapshot-note {
+            display: flex;
+            align-items: flex-start;
+            gap: 0.6rem;
+            background-color: var(--primary-light);
+            border-left: 4px solid var(--primary);
+            border-radius: var(--border-radius);
+            padding: 0.9rem 1rem;
+            font-size: 0.9rem;
+            color: var(--dark);
+            margin-bottom: 1.75rem;
+        }
+
+        .snapshot-note i {
+            color: var(--primary);
+            margin-top: 0.15rem;
+            flex-shrink: 0;
+        }
+
+        .workflow-heading {
+            font-size: 1.05rem;
+            font-weight: 600;
+            margin-bottom: 1.25rem;
+        }
+
+        .workflow-steps {
+            list-style: none;
+            counter-reset: workflow;
+            padding: 0;
+            margin: 0;
+        }
+
+        .workflow-steps li {
+            counter-increment: workflow;
+            position: relative;
+            padding-left: 3rem;
+            padding-bottom: 1.5rem;
+        }
+
+        .workflow-steps li:last-child {
+            padding-bottom: 0;
+        }
+
+        .workflow-steps li:not(:last-child)::before {
+            content: '';
+            position: absolute;
+            left: 15px;
+            top: 34px;
+            bottom: 0;
+            width: 2px;
+            background-color: var(--border-color);
+        }
+
+        .workflow-steps li::after {
+            content: counter(workflow);
+            position: absolute;
+            left: 0;
+            top: 0;
+            width: 32px;
+            height: 32px;
+            border-radius: 50%;
+            background-color: var(--primary);
+            color: white;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-weight: 600;
+            font-size: 0.9rem;
+        }
+
+        .workflow-step-title {
+            font-weight: 600;
+            margin-bottom: 0.25rem;
+            padding-top: 0.35rem;
+        }
+
+        .workflow-step-text {
+            font-size: 0.9rem;
+            color: var(--secondary);
+        }
+
         @media (max-width: 600px) {
             .form-row {
                 flex-direction: column;
@@ -140,21 +268,51 @@
         <div class="card">
             <div class="card-header"><i class="fas fa-lightbulb"></i> Program Snapshot</div>
             <div class="card-body">
-                <p>Equip yourself to advise clients on BCSB's construction-to-permanent solution. Core program elements include:</p>
-                <ul>
-                    <li>Finance up to <strong>90% loan-to-value (LTV)</strong> using the lower of total acquisition cost (lot + construction) or the appraised value.</li>
-                    <li><strong>Single close</strong> structure with 12 months of interest-only payments on funds disbursed for construction.</li>
-                    <li>Automatic conversion to a fully amortizing loan for up to a <strong>30-year term</strong> after the project reaches completion.</li>
-                    <li>Initial closing disbursement is calculated as <strong>Loan Amount − Build Price</strong>; the construction budget is managed through future draws.</li>
-                </ul>
-                <details>
-                    <summary><strong>One-time close workflow</strong></summary>
-                    <ol>
-                        <li><strong>Closing:</strong> The entire construction-to-permanent loan is documented at once. Funds beyond the construction budget release at the table.</li>
-                        <li><strong>Construction phase (up to 12 months):</strong> Draws are distributed as inspections confirm progress. The borrower remits interest-only on dollars advanced.</li>
-                        <li><strong>Conversion:</strong> When the home is complete, the note automatically transitions to long-term amortization with no second closing required.</li>
-                    </ol>
-                </details>
+                <p class="snapshot-intro">BCSB's construction-to-permanent loan lets your clients finance the lot, the build, and the permanent mortgage in a single closing. Here are the key terms at a glance:</p>
+
+                <div class="snapshot-grid">
+                    <div class="snapshot-fact">
+                        <div class="snapshot-icon"><i class="fas fa-percent"></i></div>
+                        <div class="snapshot-value">Up to 90% LTV</div>
+                        <div class="snapshot-label">Based on the lower of total acquisition cost (lot + construction) or the appraised value.</div>
+                    </div>
+                    <div class="snapshot-fact">
+                        <div class="snapshot-icon"><i class="fas fa-file-signature"></i></div>
+                        <div class="snapshot-value">Single Close</div>
+                        <div class="snapshot-label">One closing covers both the construction and permanent financing — no second closing required.</div>
+                    </div>
+                    <div class="snapshot-fact">
+                        <div class="snapshot-icon"><i class="fas fa-hourglass-half"></i></div>
+                        <div class="snapshot-value">12 Months Interest-Only</div>
+                        <div class="snapshot-label">During construction, clients pay interest only on the funds actually disbursed.</div>
+                    </div>
+                    <div class="snapshot-fact">
+                        <div class="snapshot-icon"><i class="fas fa-calendar-check"></i></div>
+                        <div class="snapshot-value">Up to 30-Year Term</div>
+                        <div class="snapshot-label">Automatically converts to a fully amortizing loan once the project is complete.</div>
+                    </div>
+                </div>
+
+                <div class="snapshot-note">
+                    <i class="fas fa-info-circle"></i>
+                    <span>The initial disbursement at closing equals <strong>Loan Amount − Build Price</strong>. The rest of the construction budget is released to the builder through future draws.</span>
+                </div>
+
+                <h4 class="workflow-heading">How the one-time close works</h4>
+                <ol class="workflow-steps">
+                    <li>
+                        <div class="workflow-step-title">Closing</div>
+                        <div class="workflow-step-text">The entire construction-to-permanent loan is documented at once. Funds beyond the construction budget release at the table.</div>
+                    </li>
+                    <li>
+                        <div class="workflow-step-title">Construction phase (up to 12 months)</div>
+                        <div class="workflow-step-text">Draws are distributed as inspections confirm progress. The borrower pays interest only on the dollars advanced.</div>
+                    </li>
+                    <li>
+                        <div class="workflow-step-title">Conversion</div>
+                        <div class="workflow-step-text">When the home is complete, the note automatically transitions to long-term amortization — no second closing required.</div>
+                    </li>
+                </ol>
             </div>
         </div>
 

--- a/process.html
+++ b/process.html
@@ -6,13 +6,139 @@
     <title>Process - BCSB</title>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
     <link href="styles.css" rel="stylesheet">
+    <style>
+        .section-intro {
+            color: var(--secondary);
+            margin-bottom: 1.5rem;
+        }
+
+        /* Contact list */
+        .contact-list {
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+        }
+
+        .contact-item {
+            display: flex;
+            align-items: center;
+            gap: 1rem;
+            padding: 1rem 1.25rem;
+            background-color: var(--light);
+            border: 1px solid var(--border-color);
+            border-radius: var(--border-radius);
+        }
+
+        .contact-icon {
+            flex-shrink: 0;
+            width: 44px;
+            height: 44px;
+            border-radius: 50%;
+            background-color: rgba(0, 102, 72, 0.1);
+            color: var(--primary);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 1.15rem;
+        }
+
+        .contact-details {
+            flex: 1;
+            min-width: 0;
+        }
+
+        .contact-scenario {
+            font-weight: 600;
+            color: var(--dark);
+            margin-bottom: 0.15rem;
+        }
+
+        .contact-name {
+            font-size: 0.9rem;
+            color: var(--secondary);
+        }
+
+        .contact-email {
+            display: inline-block;
+            font-size: 0.9rem;
+            color: var(--primary);
+            text-decoration: none;
+            word-break: break-all;
+        }
+
+        .contact-email:hover {
+            text-decoration: underline;
+        }
+
+        /* Shareable links for borrowers */
+        .share-list {
+            display: flex;
+            flex-direction: column;
+            gap: 1.25rem;
+        }
+
+        .share-item {
+            border: 1px solid var(--border-color);
+            border-radius: var(--border-radius);
+            padding: 1.25rem;
+            background-color: var(--light);
+        }
+
+        .share-title {
+            font-weight: 600;
+            color: var(--dark);
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            margin-bottom: 0.4rem;
+        }
+
+        .share-title i {
+            color: var(--primary);
+        }
+
+        .share-desc {
+            font-size: 0.9rem;
+            color: var(--secondary);
+            margin-bottom: 1rem;
+        }
+
+        .share-link-row {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+        }
+
+        .share-link-btn {
+            flex: 1;
+            min-width: 200px;
+        }
+
+        /* Copy button feedback */
+        .copy-btn.copied {
+            background-color: var(--success);
+            border-color: var(--success);
+            color: white;
+        }
+
+        @media (max-width: 600px) {
+            .contact-item {
+                flex-wrap: wrap;
+            }
+
+            .contact-details {
+                flex-basis: calc(100% - 60px);
+            }
+        }
+    </style>
 </head>
 <body>
     <header>
         <div class="container" style="display: flex; align-items: center; justify-content: space-between;">
             <div>
                 <h1>Process</h1>
-                <div class="subtitle">Understanding the BCSB process</div>
+                <div class="subtitle">Who to contact and what to share with your borrowers</div>
             </div>
             <a href="index.html" class="btn btn-primary">
                 <i class="fas fa-home"></i> Home
@@ -23,33 +149,65 @@
     <div class="container">
         <div class="card">
             <div class="card-header">
-                <i class="fas fa-address-book"></i> Contacts by Scenario
+                <i class="fas fa-address-book"></i> Who to Contact
             </div>
             <div class="card-body">
-                <div style="display: grid; gap: 1.25rem;">
-                    <div>
-                        <strong>General Scenarios</strong><br>
-                        Kristen Richard<br>
-                        <a href="mailto:Kristen.Richard@bcsbmail.com">Kristen.Richard@bcsbmail.com</a>
+                <p class="section-intro">When a scenario comes up or your client has a question, here's the right person at BCSB to reach out to.</p>
+                <div class="contact-list">
+                    <div class="contact-item">
+                        <div class="contact-icon"><i class="fas fa-comments"></i></div>
+                        <div class="contact-details">
+                            <div class="contact-scenario">General scenarios &amp; questions</div>
+                            <div class="contact-name">Kristen Richard</div>
+                            <a href="mailto:Kristen.Richard@bcsbmail.com" class="contact-email">Kristen.Richard@bcsbmail.com</a>
+                        </div>
+                        <button class="copy-btn" data-copy="Kristen.Richard@bcsbmail.com" title="Copy email address" aria-label="Copy email address">
+                            <i class="fas fa-copy"></i>
+                        </button>
                     </div>
-                    <div>
-                        <strong>Loan in Process</strong><br>
-                        Contact the Loan Processor listed in the loan file.
+
+                    <div class="contact-item">
+                        <div class="contact-icon"><i class="fas fa-tags"></i></div>
+                        <div class="contact-details">
+                            <div class="contact-scenario">Pricing &amp; lock questions</div>
+                            <div class="contact-name">Mark Moreira</div>
+                            <a href="mailto:Mark.Moreira@bcsbmail.com" class="contact-email">Mark.Moreira@bcsbmail.com</a>
+                        </div>
+                        <button class="copy-btn" data-copy="Mark.Moreira@bcsbmail.com" title="Copy email address" aria-label="Copy email address">
+                            <i class="fas fa-copy"></i>
+                        </button>
                     </div>
-                    <div>
-                        <strong>Pricing and Lock Questions</strong><br>
-                        Mark Moreira<br>
-                        <a href="mailto:Mark.Moreira@bcsbmail.com">Mark.Moreira@bcsbmail.com</a>
+
+                    <div class="contact-item">
+                        <div class="contact-icon"><i class="fas fa-file-signature"></i></div>
+                        <div class="contact-details">
+                            <div class="contact-scenario">Closing questions</div>
+                            <div class="contact-name">Melissa Reeve, Closing Officer</div>
+                            <a href="mailto:Melissa.Reeve@bcsbmail.com" class="contact-email">Melissa.Reeve@bcsbmail.com</a>
+                        </div>
+                        <button class="copy-btn" data-copy="Melissa.Reeve@bcsbmail.com" title="Copy email address" aria-label="Copy email address">
+                            <i class="fas fa-copy"></i>
+                        </button>
                     </div>
-                    <div>
-                        <strong>Closing Questions</strong><br>
-                        Melissa Reeve, Closing Officer<br>
-                        <a href="mailto:Melissa.Reeve@bcsbmail.com">Melissa.Reeve@bcsbmail.com</a>
+
+                    <div class="contact-item">
+                        <div class="contact-icon"><i class="fas fa-hard-hat"></i></div>
+                        <div class="contact-details">
+                            <div class="contact-scenario">Construction loan draw questions</div>
+                            <div class="contact-name">Amanda Araujo</div>
+                            <a href="mailto:Amanda.Araujo@bcsbmail.com" class="contact-email">Amanda.Araujo@bcsbmail.com</a>
+                        </div>
+                        <button class="copy-btn" data-copy="Amanda.Araujo@bcsbmail.com" title="Copy email address" aria-label="Copy email address">
+                            <i class="fas fa-copy"></i>
+                        </button>
                     </div>
-                    <div>
-                        <strong>Construction Loan Draw Questions</strong><br>
-                        Amanda Araujo<br>
-                        <a href="mailto:Amanda.Araujo@bcsbmail.com">Amanda.Araujo@bcsbmail.com</a>
+
+                    <div class="contact-item">
+                        <div class="contact-icon"><i class="fas fa-folder-open"></i></div>
+                        <div class="contact-details">
+                            <div class="contact-scenario">Loan already in process</div>
+                            <div class="contact-name">Contact the Loan Processor listed in the loan file.</div>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -57,27 +215,76 @@
 
         <div class="card">
             <div class="card-header">
-                <i class="fas fa-check-circle"></i> Closed Loans
+                <i class="fas fa-share-square"></i> Links to Share With Your Borrowers
             </div>
             <div class="card-body">
-                <p>For questions about payments or billing on a loan that has already closed, please contact Bristol County Savings Bank Customer Service:</p>
-                <a href="https://www.bristolcountysavings.com/customer-service" target="_blank" rel="noopener" class="btn btn-primary" style="margin-top: 1rem;">
-                    <i class="fas fa-external-link-alt"></i> BCSB Customer Service
-                </a>
-            </div>
-        </div>
+                <p class="section-intro">If a borrower reaches out to you with one of these questions, copy the link and send it their way.</p>
+                <div class="share-list">
+                    <div class="share-item">
+                        <div class="share-title"><i class="fas fa-money-check-alt"></i> Making a loan payment</div>
+                        <p class="share-desc">When a borrower needs to make a payment on their loan, share BCSB's secure online payment portal.</p>
+                        <div class="share-link-row">
+                            <a href="https://www.bristolcountysavings.com/personal/borrowing/pay-your-loan" target="_blank" rel="noopener" class="btn btn-primary share-link-btn">
+                                <i class="fas fa-external-link-alt"></i> Pay Your Loan
+                            </a>
+                            <button class="copy-btn" data-copy="https://www.bristolcountysavings.com/personal/borrowing/pay-your-loan" title="Copy link" aria-label="Copy link">
+                                <i class="fas fa-copy"></i>
+                            </button>
+                        </div>
+                    </div>
 
-        <div class="card">
-            <div class="card-header">
-                <i class="fas fa-money-check-alt"></i> Loan Payments
-            </div>
-            <div class="card-body">
-                <p>To make a payment on your loan, please visit:</p>
-                <a href="https://www.bristolcountysavings.com/personal/borrowing/pay-your-loan" target="_blank" rel="noopener" class="btn btn-primary" style="margin-top: 1rem;">
-                    <i class="fas fa-external-link-alt"></i> Pay Your Loan
-                </a>
+                    <div class="share-item">
+                        <div class="share-title"><i class="fas fa-check-circle"></i> Questions on a closed loan</div>
+                        <p class="share-desc">For a borrower's questions about payments or billing on a loan that has already closed, point them to BCSB Customer Service.</p>
+                        <div class="share-link-row">
+                            <a href="https://www.bristolcountysavings.com/customer-service" target="_blank" rel="noopener" class="btn btn-primary share-link-btn">
+                                <i class="fas fa-external-link-alt"></i> BCSB Customer Service
+                            </a>
+                            <button class="copy-btn" data-copy="https://www.bristolcountysavings.com/customer-service" title="Copy link" aria-label="Copy link">
+                                <i class="fas fa-copy"></i>
+                            </button>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
     </div>
+
+    <script>
+        document.querySelectorAll('.copy-btn[data-copy]').forEach(function (btn) {
+            btn.addEventListener('click', function () {
+                var text = btn.getAttribute('data-copy');
+
+                function showCopied() {
+                    var icon = btn.querySelector('i');
+                    var original = icon.className;
+                    icon.className = 'fas fa-check';
+                    btn.classList.add('copied');
+                    setTimeout(function () {
+                        icon.className = original;
+                        btn.classList.remove('copied');
+                    }, 1500);
+                }
+
+                function fallbackCopy() {
+                    var ta = document.createElement('textarea');
+                    ta.value = text;
+                    ta.style.position = 'fixed';
+                    ta.style.opacity = '0';
+                    document.body.appendChild(ta);
+                    ta.select();
+                    try { document.execCommand('copy'); } catch (e) {}
+                    document.body.removeChild(ta);
+                    showCopied();
+                }
+
+                if (navigator.clipboard && navigator.clipboard.writeText) {
+                    navigator.clipboard.writeText(text).then(showCopied).catch(fallbackCopy);
+                } else {
+                    fallbackCopy();
+                }
+            });
+        });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
- Rebuild the Program Snapshot as scannable fact cards (LTV, single
  close, interest-only, term) plus a clean numbered workflow instead
  of a dense bullet/details block.
- Reframe the process page for mortgage brokers: 'Who to Contact'
  cards and a 'Links to Share With Your Borrowers' section phrased
  around helping clients rather than paying your own loan.
- Add copy buttons to contact emails and shareable links with
  copied-state feedback.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XgE3RJVKgj76z4AgNKetfq